### PR TITLE
Add Docker support with Dockerfile and run script; update dotenv config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.git
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM docker.io/node:22-bookworm-slim
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+ENV NODE_ENV=development
+
+# `npm ci` on start restores node_modules when you bind-mount the repo (mount hides image layers).
+CMD ["sh", "-c", "npm ci && exec npm run dev"]

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "type": "commonjs",
   "main": "src/index.js",
   "scripts": {
+    "dev": "node --watch src/index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {

--- a/run_podman.sh
+++ b/run_podman.sh
@@ -1,0 +1,6 @@
+podman build -t discord-pet-js:dev .
+
+# Load secrets from the repo’s `.env` (mounted at /app); avoid `--env-file` so token edits apply after restart.
+podman run -it --rm \
+  -v "$PWD:/app:Z" \
+  discord-pet-js:dev

--- a/src/discord_tools/client.js
+++ b/src/discord_tools/client.js
@@ -5,7 +5,7 @@ const dotenv = require('dotenv');
 require('./command')
 const { log } = require('../utils/logger');
 
-dotenv.config();
+dotenv.config({ override: true });
 
 const client = new Client({
     intents: [

--- a/src/discord_tools/command.js
+++ b/src/discord_tools/command.js
@@ -4,7 +4,7 @@ const fsPromises = require('node:fs').promises;
 const path = require('node:path');
 const dotenv = require('dotenv');
 
-dotenv.config();
+dotenv.config({ override: true });
 
 const commands = [];
 // Grab all the command folders from the commands directory you created earlier


### PR DESCRIPTION
- Created .dockerignore to exclude node_modules, .git, and .env from Docker context.
- Added Dockerfile for building a Node.js application image with development environment setup.
- Introduced run_podman.sh script for building and running the container using Podman.
- Updated package.json to include a development script for hot-reloading.
- Modified dotenv configuration in client.js and command.js to allow overriding existing environment variables.